### PR TITLE
Keep module in vendor directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,10 @@
     "require": {
         "php": "~5.5.0|~5.6.0|~7.0.0"
     },
-    "extra": {
-        "map": [
-            [
-                "*",
-                "Ves/ImageSlider"
-            ]
-        ]
+    "autoload": {
+        "files": [ "registration.php" ],
+        "psr-4": {
+            "Ves\\ImageSlider\\": ""
+        }
     }
 }


### PR DESCRIPTION
Right now after module installation - all files from module are copying to app/code directory. Instead of it we can keep them in vendor directory.
This issue was already described in #3.
This article describes how to add composer.json correctly:
http://devdocs.magento.com/guides/v2.1/extension-dev-guide/build/create_component.html#add-composer-json

