### PR TITLE
Add shim configuration to avoid race conditions

### DIFF
--- a/view/frontend/templates/widget/slides.phtml
+++ b/view/frontend/templates/widget/slides.phtml
@@ -57,37 +57,45 @@ $previous_icon_class = $this->getConfig('previous_icon_class');
 	</div>
 </div>
 <script>
-	require([
-		'jquery',
-		"Ves_ImageSlider/js/owl.carousel.min"
-	],function(){
-		jQuery(document).ready(function() {
-			var owl = jQuery('#imageslider-<?php echo $blockId ?>');
-			owl.owlCarousel({
-				animateOut: <?php echo $animateOut?'"'.$animateOut.'"':"false"; ?>,
-				animateIn: <?php echo $animateIn?'"'.$animateIn.'"':"false"; ?>,
-				items:1,
-				dots: <?php echo $dots?"true":"false" ?>,
-				nav: <?php echo $nav?"true":"false" ?>,
-				loop: <?php echo $loop?"true":"false" ?>,
-				autoplay: <?php echo $autoplay?"true":"false" ?>,
-				autoplayTimeout: <?php echo (int)$autoplay_timeout ?>,
-				autoplaySpeed: <?php echo $autoplay_speed?(int)$autoplay_speed:'false'; ?>,
-				navSpeed:  <?php echo $nav_speed?(int)$nav_speed:'false'; ?>,
-				dotsSpeed: <?php echo $dots_speed?(int)$dots_speed:'false'; ?>,
-				autoplayHoverPause: <?php echo $autoplay_hover?"true":"false" ?>,
-				autoHeight: <?php echo $autoheight?"true":"false" ?>,
-				lazyLoad: <?php echo $lazyLoad?"true":"false" ?>,
-				touchDrag: <?php echo $touchDrag?"true":"false" ?>,
-				mouseDrag: <?php echo $mouseDrag?"true":"false" ?>,
-				pullDrag: <?php echo $pullDrag?"true":"false" ?>,
-			});
-			jQuery(".prev<?php echo $blockId ?>").click(function () {
-				owl.trigger('prev.owl.carousel');
-			});
-			jQuery(".next<?php echo $blockId ?>").click(function () {
-				owl.trigger('next.owl.carousel');
-			});
-		});
-	});
+    require.config(
+        {
+            shim: {
+                "Ves_ImageSlider/js/owl.carousel.min": ['jquery']
+            },
+            deps: [
+                'jquery',
+                "Ves_ImageSlider/js/owl.carousel.min"
+            ],
+            callback: function ($, owl) {
+                $(document).ready(function () {
+                    var owl = $('#imageslider-<?php echo $blockId ?>');
+                    owl.owlCarousel({
+                        animateOut: <?php echo $animateOut ? '"' . $animateOut . '"' : "false"; ?>,
+                        animateIn: <?php echo $animateIn ? '"' . $animateIn . '"' : "false"; ?>,
+                        items: 1,
+                        dots: <?php echo $dots ? "true" : "false" ?>,
+                        nav: <?php echo $nav ? "true" : "false" ?>,
+                        loop: <?php echo $loop ? "true" : "false" ?>,
+                        autoplay: <?php echo $autoplay ? "true" : "false" ?>,
+                        autoplayTimeout: <?php echo (int) $autoplay_timeout ?>,
+                        autoplaySpeed: <?php echo $autoplay_speed ? (int) $autoplay_speed : 'false'; ?>,
+                        navSpeed:  <?php echo $nav_speed ? (int) $nav_speed : 'false'; ?>,
+                        dotsSpeed: <?php echo $dots_speed ? (int) $dots_speed : 'false'; ?>,
+                        autoplayHoverPause: <?php echo $autoplay_hover ? "true" : "false" ?>,
+                        autoHeight: <?php echo $autoheight ? "true" : "false" ?>,
+                        lazyLoad: <?php echo $lazyLoad ? "true" : "false" ?>,
+                        touchDrag: <?php echo $touchDrag ? "true" : "false" ?>,
+                        mouseDrag: <?php echo $mouseDrag ? "true" : "false" ?>,
+                        pullDrag: <?php echo $pullDrag ? "true" : "false" ?>,
+                    });
+                    $(".prev<?php echo $blockId ?>").click(function () {
+                        owl.trigger('prev.owl.carousel');
+                    });
+                    $(".next<?php echo $blockId ?>").click(function () {
+                        owl.trigger('next.owl.carousel');
+                    });
+                });
+            }
+        })
+    ;
 </script>


### PR DESCRIPTION
Problem was that in some cases, owl carousel was loaded before jquery, leading to problems
Adding the shim configuration avoids that